### PR TITLE
Update FortiOS version to 6.4.5 & lock terraform version to 0.14.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Additionally, the script will also initiate an AWS Inspector run on the Ubuntu instance in the private subnet.
 
 ## Requirements
-* [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) 0.14
+* [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) 0.14.4
 * An [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)
 * FortiOS 6.4.4
 * Environment with **expect** tool support https://core.tcl-lang.org/expect/index

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 
 }
 terraform {
-  required_version = "> 0.14.0"
+  required_version = "0.14.4"
   required_providers {
     fortios = {
       source  = "fortinetdev/fortios"
@@ -526,7 +526,7 @@ resource "aws_network_interface" "fgt_second_nic" {
   depends_on = [aws_instance.fortigate]
 }
 resource "aws_instance" "fortigate" {
-  ami                    = "ami-08f558c88d066cd22"                 //6.4.4 GA B1803  us-west-1
+  ami                    = "ami-0109010188b5b573b"                 //6.4.5 GA B1803  us-west-1
   iam_instance_profile   = aws_iam_instance_profile.fortidemo.name //IAM permissions for SDN connector
   availability_zone      = var.az_default
   instance_type          = "c5.large"

--- a/main.tf
+++ b/main.tf
@@ -526,7 +526,7 @@ resource "aws_network_interface" "fgt_second_nic" {
   depends_on = [aws_instance.fortigate]
 }
 resource "aws_instance" "fortigate" {
-  ami                    = "ami-0109010188b5b573b"                 //6.4.5 GA B1803  us-west-1
+  ami                    = "ami-0109010188b5b573b"                 //6.4.5 GA B1828  us-west-1
   iam_instance_profile   = aws_iam_instance_profile.fortidemo.name //IAM permissions for SDN connector
   availability_zone      = var.az_default
   instance_type          = "c5.large"


### PR DESCRIPTION
FortiOS v6.4.4 Build 1803 has been removed from the AWS Marketplace. 
Updating v6.4.5 Build 1828. 

Locking Terraform version to 0.14.4 after complaints about incompatibility with newer versions from some users.  